### PR TITLE
bitfield.js takes named arguments (CLI)

### DIFF
--- a/bin/bitfield.js
+++ b/bin/bitfield.js
@@ -8,11 +8,25 @@ var lib = require('../lib'),
 
 var argv = yargs.count('icestorm').argv;
 var fileName;
+var options = {
+    vspace: 80,
+    hspace: 640,
+    lanes: 2,
+    bits: 32
+};
 
-if (argv._.length === 1) {
-    fileName = argv._[0];
+if (argv.input){
+    if (argv.vspace && argv.hspace && argv.lanes && argv.bits){
+        options = {
+            vspace: argv.vspace,
+            hspace: argv.hspace,
+            lanes: argv.lanes,
+            bits: argv.bits
+        };
+    }
+    fileName = argv.input;
     fs.readJson(fileName, function (err, src) {
-        var res = lib.render(src);
+        var res = lib.render(src, options);
         var svg = onml.s(res);
         console.log(svg);
     });


### PR DESCRIPTION
--input : input JSON filename - must be specified always
--vspace : vertical space - default 80
--hspace : horizontal space - default 640
--lanes : rectangle lanes - default 2
--bits : overall bitwidth - default 32
** by default 2 lanes, 16bit each (total 32bit) rectangles to be generated **