### PR TITLE
Feature: font family, font size, font weight

### DIFF
--- a/bin/bitfield.js
+++ b/bin/bitfield.js
@@ -17,7 +17,7 @@ var options = {
     bigendian: argv.gigendian || false,
     fontfamily: argv.fontfamily || "sans-serif",
     fontweight : argv.fontweight || "normal",
-    fontsize : argv:fontsize || 14,
+    fontsize : argv.fontsize || 14,
 };
 
 if (argv.input) {

--- a/bin/bitfield.js
+++ b/bin/bitfield.js
@@ -20,9 +20,21 @@ if (argv.input){
     if(argv.hspace){options.hspace = argv.hspace}
     if(argv.lanes){options.lanes = argv.lanes}
     if(argv.bits){options.bits = argv.bits}
-    if(argv.fontfamily){options.fontfamily = argv.fontfamily}
-    if(argv.fontweight){options.fontweight = argv.fontweight}
-    if(argv.fontsize){options.fontsize = argv.fontsize}
+    if(argv.fontfamily){
+      options.fontfamily = argv.fontfamily
+    }else{
+      options.fontfamily = "sans-serif" // default
+    }
+    if(argv.fontweight){
+      options.fontweight = argv.fontweight
+    }else{
+      options.fontweight = "normal" // default
+    }
+    if(argv.fontsize){
+      options.fontsize = argv.fontsize
+    }else{
+      options.fontsize = 14 // default
+    }
 
     fileName = argv.input;
     fs.readJson(fileName, function (err, src) {

--- a/bin/bitfield.js
+++ b/bin/bitfield.js
@@ -16,14 +16,21 @@ var options = {
 };
 
 if (argv.input){
-    if (argv.vspace && argv.hspace && argv.lanes && argv.bits){
-        options = {
-            vspace: argv.vspace,
-            hspace: argv.hspace,
-            lanes: argv.lanes,
-            bits: argv.bits
-        };
-    }
+    if(argv.vspace){options.vspace = argv.vspace}
+    if(argv.hspace){options.hspace = argv.hspace}
+    if(argv.lanes){options.lanes = argv.lanes}
+    if(argv.bits){options.bits = argv.bits}
+    if(argv.font_family){options.font_family = argv.font_family}
+
+    // if (argv.vspace && argv.hspace && argv.lanes && argv.bits){
+    //   // console.log(options.vspace);
+    //     options = {
+    //         vspace: argv.vspace,
+    //         hspace: argv.hspace,
+    //         lanes: argv.lanes,
+    //         bits: argv.bits
+    //     };
+    // }
     fileName = argv.input;
     fs.readJson(fileName, function (err, src) {
         var res = lib.render(src, options);

--- a/bin/bitfield.js
+++ b/bin/bitfield.js
@@ -20,17 +20,10 @@ if (argv.input){
     if(argv.hspace){options.hspace = argv.hspace}
     if(argv.lanes){options.lanes = argv.lanes}
     if(argv.bits){options.bits = argv.bits}
-    if(argv.font_family){options.font_family = argv.font_family}
+    if(argv.fontfamily){options.fontfamily = argv.fontfamily}
+    if(argv.fontweight){options.fontweight = argv.fontweight}
+    if(argv.fontsize){options.fontsize = argv.fontsize}
 
-    // if (argv.vspace && argv.hspace && argv.lanes && argv.bits){
-    //   // console.log(options.vspace);
-    //     options = {
-    //         vspace: argv.vspace,
-    //         hspace: argv.hspace,
-    //         lanes: argv.lanes,
-    //         bits: argv.bits
-    //     };
-    // }
     fileName = argv.input;
     fs.readJson(fileName, function (err, src) {
         var res = lib.render(src, options);

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,9 @@ function labelArr (desc, options) {
     var names = ['g', {transform: t(step / 2, options.vspace / 2 + 4)}];
     var attrs = ['g', {transform: t(step / 2, options.vspace)}];
     var blanks = ['g', {transform: t(0, options.vspace / 4)}];
-    var style = (options.font_family ? "font-family: " + options.font_family : "")
+    var fontsize = options.fontsize;
+    var fontfamily = options.fontfamily;
+    var fontweight = options.fontweight;
     desc.forEach(function (e) {
         var lText, aText, lsbm, msbm, lsb, msb;
         lsbm = 0;
@@ -69,15 +71,24 @@ function labelArr (desc, options) {
             }
         }
         bits.push(['text', { x: step * (options.mod - lsbm - 1),
-                            style}, lsb]);
+                            'font-size': fontsize,
+                            'font-family': fontfamily,
+                            'font-weight': fontweight
+                            }, lsb]);
         if (lsbm !== msbm) {
             bits.push(['text', { x: step * (options.mod - msbm - 1),
-                                style }, msb]);
+                            'font-size': fontsize,
+                            'font-family': fontfamily,
+                            'font-weight': fontweight
+                                 }, msb]);
         }
         if (e.name) {
             lText = tspan.parse(e.name);
             lText.unshift({ x: step * (options.mod - ((msbm + lsbm) / 2) - 1),
-                            style });
+                            'font-size': fontsize,
+                            'font-family': fontfamily,
+                            'font-weight': fontweight
+                             });
             lText.unshift('text');
             names.push(lText);
         } else {
@@ -92,7 +103,10 @@ function labelArr (desc, options) {
         if (e.attr) {
             aText = tspan.parse(e.attr);
             aText.unshift({ x: step * (options.mod - ((msbm + lsbm) / 2) - 1),
-                            style });
+                            'font-size': fontsize,
+                            'font-family': fontfamily,
+                            'font-weight': fontweight
+                             });
             aText.unshift('text');
             attrs.push(aText);
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -168,10 +168,10 @@ function render (desc, options) {
     var res = ['svg', {
         xmlns: 'http://www.w3.org/2000/svg',
         width: (options.hspace + 9),
-        height: (options.vspace * options.lanes + 1),
+        height: (options.vspace * options.lanes + 5),
         viewBox: [0, 0,
             (options.hspace + 9),
-            (options.vspace * options.lanes + 1)
+            (options.vspace * options.lanes + 5)
         ].join(' ')
     }];
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,6 +46,7 @@ function labelArr (desc, options) {
     var names = ['g', {transform: t(step / 2, options.vspace / 2 + 4)}];
     var attrs = ['g', {transform: t(step / 2, options.vspace)}];
     var blanks = ['g', {transform: t(0, options.vspace / 4)}];
+    var style = (options.font_family ? "font-family: " + options.font_family : "")
     desc.forEach(function (e) {
         var lText, aText, lsbm, msbm, lsb, msb;
         lsbm = 0;
@@ -67,13 +68,16 @@ function labelArr (desc, options) {
                 return;
             }
         }
-        bits.push(['text', { x: step * (options.mod - lsbm - 1) }, lsb]);
+        bits.push(['text', { x: step * (options.mod - lsbm - 1),
+                            style}, lsb]);
         if (lsbm !== msbm) {
-            bits.push(['text', { x: step * (options.mod - msbm - 1) }, msb]);
+            bits.push(['text', { x: step * (options.mod - msbm - 1),
+                                style }, msb]);
         }
         if (e.name) {
             lText = tspan.parse(e.name);
-            lText.unshift({ x: step * (options.mod - ((msbm + lsbm) / 2) - 1) });
+            lText.unshift({ x: step * (options.mod - ((msbm + lsbm) / 2) - 1),
+                            style });
             lText.unshift('text');
             names.push(lText);
         } else {
@@ -87,7 +91,8 @@ function labelArr (desc, options) {
         }
         if (e.attr) {
             aText = tspan.parse(e.attr);
-            aText.unshift({ x: step * (options.mod - ((msbm + lsbm) / 2) - 1) });
+            aText.unshift({ x: step * (options.mod - ((msbm + lsbm) / 2) - 1),
+                            style });
             aText.unshift('text');
             attrs.push(aText);
         }


### PR DESCRIPTION
## This PR adds following options to control some of font configuration:

- `fontfamily` to specify font family. 
    - Case insensitive. 
    - Should be quoted. 
    - "ms gothic", "source code pro" etc.
    - *Default: "sans-serif"*
- `fontweight` to specify font weight.
    - Depends on font family. 
    - Should be quoted. 
    - "bold", "300" etc.
    - *Default: "normal"*
- `fontsize` to specify font size. 
    - *Default: 14*
---
### possible issue
These options affects all appearance of characters at once.
`--fontsize 30` makes 30-point font for bit numbering, field name and attributes