### PR TITLE
Promote fs-extra, onml, and yargs to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,18 +15,18 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^4.10.0",
-    "fs-extra": "^4.0.2",
     "jsof": "^0.3.1",
     "mocha": "^4.0.1",
-    "onml": "^0.4.0",
-    "nyc": "^11.3.0",
-    "yargs": "^10.0.3"
+    "nyc": "^11.3.0"
   },
   "directories": {
     "test": "test"
   },
   "dependencies": {
-    "tspan": "^0.2.1"
+    "fs-extra": "^4.0.2",
+    "onml": "^0.4.0",
+    "tspan": "^0.2.1",
+    "yargs": "^10.0.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
In a clean NPM environemnt, npm i bit-field yields a bitfield that fails
to run.  fs-extra, onml, and yargs are required for execution but are
listed only as devDepdencies.  Promoting them to dependencies ensures
they are installed when bit-field is installed.

Signed-off-by: Rick Altherr <kc8apf@kc8apf.net>