### PR TITLE
Fixed Example Code Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm i bit-field
 ## Library usage
 
 ```js
-var render = require('bit-filed/lib/render');
+var render = require('bit-field/lib/render');
 var onml = require('onml');
 
 var reg = [


### PR DESCRIPTION
Fixed typo 'bit-filed/lib/render' to 'bit-field/lib/render'