### PR TITLE
reg: allow all-zeros as name for fields

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -118,7 +118,7 @@ const labelArr = (desc, opt) => {
         bits.push(text(msb, step * (vflip ? msbm : (mod - msbm - 1))));
       }
     }
-    if (e.name) {
+    if (e.name !== undefined) {
       names.push(getLabel(
         e.name,
         step * (vflip


### PR DESCRIPTION
Assume a register-diagram with all-zeros for one of the register fields:
       { reg:[ { bits:  7, name: 0x3b, attr: ['OP-32'] },
	       { bits:  5, name: 'rd' },
	       { bits:  3, name: 0x0, attr: ['ADD.UW'] },
	       { bits:  5, name: 'rs1' },
	       { bits:  5, name: 'rs2' },
	       { bits:  7, name: 0x04, attr: ['ADD.UW'] } ] }

We expect the field with 3 bits to be labeled as 0|0|0.  However, the
current implementation skips printing the name, as it does not
differentiate between an unnamed field (i.e. without any name defined)
or one that has the integer-value 0 as its name.

This adjusts the behaviour by explicitly checking whether name is
undefined to determine whether the name should be printed.

Signed-off-by: Philipp Tomsich <philipp.tomsich@vrull.eu>