### PR TITLE
Allow Uneven lanes

### DIFF
--- a/bin/bitfield.js
+++ b/bin/bitfield.js
@@ -19,6 +19,7 @@ var argv = yargs
   .option('compact', {describe: 'compact format', type: 'boolean', default: false})
   .option('hflip', {describe: 'horizontal flip', type: 'boolean', default: false})
   .option('vflip', {describe: 'vertical flip', type: 'boolean', default: false})
+  .option('uneven', {describe: 'make lanes uneven if bitsize is odd', type: 'boolean', default: false})
   .demandOption(['input'])
   .help()
   .argv;

--- a/lib/render.js
+++ b/lib/render.js
@@ -184,7 +184,7 @@ const compactLabels = (desc, opt) => {
 };
 
 const cage = (desc, opt) => {
-  const {hspace, vspace, mod, margin, index, vflip} = opt;
+  const {hspace, vspace, mod, margin, index, vflip, hflip} = opt;
   const width = hspace - margin.left - margin.right - 1;
   const height = vspace - margin.top - margin.bottom;
   const res = ['g',
@@ -192,11 +192,22 @@ const cage = (desc, opt) => {
       stroke: 'black',
       'stroke-width': 1,
       'stroke-linecap': 'round'
-    },
-    hline(width, 0, 0),
-    vline(height, (vflip ? width : 0), 0),
-    hline(width, 0, height)
+    }
   ];
+  const skip_edge = opt.uneven && (opt.bits % 2 === 1) && (index === (opt.lanes - 1));
+  if (skip_edge) {
+    if (vflip) {
+      res.push(hline(width - (width / mod), 0, 0));
+      res.push(hline(width - (width / mod), 0, height));
+    } else {
+      res.push(hline(width - (width / mod), width / mod, 0));
+      res.push(hline(width - (width / mod), width / mod, height));
+    }
+  } else {
+    res.push(hline(width, 0, 0));
+    res.push(hline(width, 0, height));
+    res.push(vline(height, (vflip ? width : 0), 0));
+  }
 
   let i = index * mod;
   const delta = vflip ? 1 : -1;

--- a/lib/render.js
+++ b/lib/render.js
@@ -204,7 +204,7 @@ const cage = (desc, opt) => {
 
   for (let k = 0; k < mod; k++) {
     const xj = j * (width / mod);
-    if ((k === 0) || desc.some(e => (e.lsb === i))) {
+    if ((k === 0) || desc.some(e => (e.msb + 1 === i))) {
       res.push(vline(height, xj, 0));
     } else {
       res.push(vline((height >>> 3), xj, 0));
@@ -308,6 +308,7 @@ const render = (desc, opt) => {
   opt.fontweight = opt.fontweight || 'normal';
   opt.compact = opt.compact || false;
   opt.hflip = opt.hflip || false;
+  opt.uneven = opt.uneven || false;
   opt.margin = opt.margin || {};
 
   const {hspace, vspace, lanes, margin, compact, fontsize, bits, label} = opt;
@@ -354,7 +355,7 @@ const render = (desc, opt) => {
   ];
 
   let lsb = 0;
-  const mod = bits / lanes;
+  const mod = Math.ceil(bits * 1.0 / lanes);
   opt.mod = mod | 0;
 
   desc.map(e => {


### PR DESCRIPTION
In the current version if the number of bits is odd the last lane gets a padding, with this one (if one passes --uneven flag) last lane is left as-is

I didn't enable it by default to not mess with existing json files.