### PR TITLE
Ability to skip drawing empty bitfields

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -135,13 +135,15 @@ const labelArr = (desc, opt) => {
     }
 
     if ((e.name === undefined) || (e.type !== undefined)) {
-      blanks.push(['rect', norm({
-        x: step * (vflip ? lsbm : (mod - msbm - 1)),
-        width: step * (msbm - lsbm + 1),
-        height: height
-      }, {
-        style: 'fill-opacity:0.1' + typeStyle(e.type)
-      })]);
+      if (!(opt.compact && e.type === undefined)) {
+        blanks.push(['rect', norm({
+          x: step * (vflip ? lsbm : (mod - msbm - 1)),
+          width: step * (msbm - lsbm + 1),
+          height: height
+        }, {
+          style: 'fill-opacity:0.1' + typeStyle(e.type)
+        })]);
+      }
     }
     if (e.attr !== undefined) {
       attrs.push(getAttr(e, opt, step, lsbm, msbm));
@@ -183,6 +185,28 @@ const compactLabels = (desc, opt) => {
   return labels;
 };
 
+const skipDrawingEmptySpace = (desc, opt, laneIndex, laneLength, globalIndex) => {
+  if (!opt.compact)
+    return false;
+  
+  const isEmptyBitfield = (bitfield) => bitfield.name === undefined && bitfield.type === undefined;
+  var bitfieldIndex = desc.findIndex((e) => isEmptyBitfield(e) && globalIndex >= e.lsb && globalIndex <= e.msb + 1);
+
+  if (bitfieldIndex === -1)
+    return false;
+
+  if (globalIndex > desc[bitfieldIndex].lsb && globalIndex < desc[bitfieldIndex].msb + 1)
+    return true;
+
+  if (globalIndex == desc[bitfieldIndex].lsb && (laneIndex === 0 || bitfieldIndex > 0 && isEmptyBitfield(desc[bitfieldIndex - 1])))
+    return true;
+  
+  if (globalIndex == desc[bitfieldIndex].msb + 1 && (laneIndex === laneLength || bitfieldIndex < desc.length - 1 && isEmptyBitfield(desc[bitfieldIndex + 1])))
+    return true;
+          
+  return false;
+}
+
 const cage = (desc, opt) => {
   const {hspace, vspace, mod, margin, index, vflip} = opt;
   const width = hspace - margin.left - margin.right - 1;
@@ -203,7 +227,7 @@ const cage = (desc, opt) => {
       res.push(hline(width - (width / mod), width / mod, 0));
       res.push(hline(width - (width / mod), width / mod, height));
     }
-  } else {
+  } else if (!opt.compact) {
     res.push(hline(width, 0, 0));
     res.push(hline(width, 0, height));
     res.push(vline(height, (vflip ? width : 0), 0));
@@ -212,15 +236,27 @@ const cage = (desc, opt) => {
   let i = index * mod;
   const delta = vflip ? 1 : -1;
   let j = vflip ? 0 : mod;
-
-  for (let k = 0; k < mod; k++) {
+  
+  for (let k = 0; k <= mod; k++) {
+    if (skipDrawingEmptySpace(desc, opt, k, mod, i)) {
+      i++;
+      j += delta;
+      continue;
+    }
+    
     const xj = j * (width / mod);
-    if ((k === 0) || desc.some(e => (e.msb + 1 === i))) {
+    if ((k === 0) || (k === mod) || desc.some(e => (e.msb + 1 === i))) {
       res.push(vline(height, xj, 0));
     } else {
       res.push(vline((height >>> 3), xj, 0));
       res.push(vline(-(height >>> 3), xj, height));
     }
+
+    if (opt.compact && k !== 0 && !skipDrawingEmptySpace(desc, opt, k - 1, mod, i - 1)) {
+      res.push(hline(width / mod, xj, 0));
+      res.push(hline(width / mod, xj, height));
+    }
+
     i++;
     j += delta;
   }
@@ -305,6 +341,7 @@ const isIntGTorDefault = opt => row => {
 
 const render = (desc, opt) => {
   opt = (typeof opt === 'object') ? opt : {};
+
 
   [ // key         min default
     // ['vspace', 20, 60],


### PR DESCRIPTION
This PR request will allow represent packed structs/unions when in compact mode, by skipping empty bitfields.
**`Empty bitfield`** == no name && no type

Input example:

```
{reg: [
{bits:2, name:'id', type:5, attr:''},
{bits:32, name:'union_fields', type:7, attr:''},
{bits:8, name:'nested', type:4, attr:''},
{bits: 34},
{bits:1, name:'a', type:3, attr:''},
{bits:2, name:'b', type:3, attr:''},
{bits:5, name:'other_nested', type:4, attr:''},
{bits: 2},
{bits:32, name:'type_0', type:4, attr:''},
{bits: 3},
{bits:5, name:'c', type:3, attr:''},
{bits: 2},
{bits:8, name:'field_0', type:3, attr:''},
{bits:8, name:'field_1', type:3, attr:''},
{bits:8, name:'field_2', type:3, attr:''},
{bits:8, name:'field_3', type:3, attr:''},
{bits: 8},
{bits: 42},
{bits: 2},
{bits:32, name:'type_1', type:4, attr:''},
{bits: 8},
{bits: 2},
{bits:16, name:'field_a', type:3, attr:''},
{bits:16, name:'field_b', type:3, attr:''},
{bits: 8},
{bits: 42},
{bits: 2},
{bits:32, name:'type_2', type:4, attr:''},
{bits: 8},
{bits: 2},
{bits:32, name:'field_alpha', type:3, attr:''},
{bits: 8},
{bits: 42},
{bits: 2},
{bits:32, name:'type_3', type:4, attr:''},
{bits: 8},
{bits: 2},
{bits:24, name:'padding', type:3, attr:''},
{bits:8, name:'other_field', type:4, attr:''},
{bits: 8},
{bits: 26},
{bits:1, name:'x', type:3, attr:''},
{bits:1, name:'y', type:3, attr:''},
{bits:6, name:'z', type:3, attr:''},
{bits: 8},
]
, config:{bits:588, lanes: 14, hspace:1050, compact: true, hflip: true }
}
```

Output:

![bitfields_of_top_struct_t (1)](https://user-images.githubusercontent.com/54810282/186617982-50ed2e6f-e5f3-462c-9aed-2b1298f162d4.png)

