### PR TITLE
Ability to add legend items

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -161,11 +161,42 @@ const getLabelMask = (desc, mod) => {
   return mask;
 };
 
+const getLegendItems = (opt) => {
+  const {hspace, margin, fontsize, legend} = opt;
+  const width = hspace - margin.left - margin.right - 1;
+  const items = ['g', tt(margin.left, -10)];
+  const legendSquarePadding = 36;
+  const legendNamePadding = 24;
+
+  var x = width / 2 - Object.keys(legend).length / 2 * (legendSquarePadding + legendNamePadding);
+  for(var key in legend) {
+    var value = legend[key];
+
+    items.push(['rect', norm({
+      x: x,
+      width: 12,
+      height: 12
+    }, {
+      style: 'fill-opacity:0.15; stroke: #000; stroke-width: 1.2;' + typeStyle(value)
+    })]);
+
+    x += legendSquarePadding;
+    items.push(text(
+        key,
+        x,
+        0.1 * fontsize + 4
+      ));
+      x += legendNamePadding;
+  }
+
+  return items;
+};
+
 const compactLabels = (desc, opt) => {
-  const {hspace, margin, mod, fontsize, vflip} = opt;
+  const {hspace, margin, mod, fontsize, vflip, legend} = opt;
   const width = hspace - margin.left - margin.right - 1;
   const step = width / mod;
-  const labels = ['g', tt(margin.left, -3)];
+  const labels = ['g', tt(margin.left, legend ? 0 : -3)];
 
   const mask = getLabelMask(desc, mod);
 
@@ -328,7 +359,7 @@ const render = (desc, opt) => {
     opt.bits = getTotalBits(desc);
   }
 
-  const {hspace, vspace, lanes, margin, compact, fontsize, bits, label} = opt;
+  const {hspace, vspace, lanes, margin, compact, fontsize, bits, label, legend} = opt;
 
   if (margin.right === undefined) {
     if (label && label.right !== undefined) {
@@ -363,7 +394,7 @@ const render = (desc, opt) => {
   }
 
   const res = ['g',
-    tt(0.5, 0.5, {
+    tt(0.5, legend ? 12.5 : 0.5, {
       'text-anchor': 'middle',
       'font-size': opt.fontsize,
       'font-family': opt.fontfamily,
@@ -390,6 +421,11 @@ const render = (desc, opt) => {
   if (compact) {
     res.push(compactLabels(desc, opt));
   }
+
+  if (legend) {
+    res.push(getLegendItems(opt));
+  }
+
   return getSVG(width, height).concat([res]);
 };
 


### PR DESCRIPTION
The items can be specified in the config as: `legend: {struct: 4, union: 7, enum: 5, field: 3}`

![bitfields_of_PActions_t](https://user-images.githubusercontent.com/54810282/186849676-71f72586-f344-4496-985a-40d3ead025e1.svg)

