### PR TITLE
Fixed legend bug and missing attribute for rectangles

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -141,6 +141,7 @@ const labelArr = (desc, opt) => {
           width: step * (msbm - lsbm + 1),
           height: height
         }, {
+          field: e.name,
           style: 'fill-opacity:0.1' + typeStyle(e.type)
         })]);
       }
@@ -171,7 +172,7 @@ const getLegendItems = (opt) => {
   const legendNamePadding = 24;
 
   let x = width / 2 - Object.keys(legend).length / 2 * (legendSquarePadding + legendNamePadding);
-  for(const key of legend) {
+  for(const key in legend) {
     const value = legend[key];
 
     items.push(['rect', norm({


### PR DESCRIPTION
The legend argument is an object, not an array and also the new attribute introduced by #45  is missing.