### PR TITLE
Fix missing gap for empty bitfield when in compact mode

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -274,24 +274,40 @@ const cage = (desc, opt) => {
   const delta = vflip ? 1 : -1;
   let j = vflip ? 0 : mod;
 
-  for (let k = 0; k <= mod; k++) {
-    const xj = j * (width / mod);
+  if (opt.sparse) {
+    for (let k = 0; k <= mod; k++) {
+      const xj = j * (width / mod);
 
-    if ((!skipField(desc, opt, i) && k !== 0) || (!skipField(desc, opt, i+1) && k !== mod)) {
+      if ((!skipField(desc, opt, i) && k !== 0) || (!skipField(desc, opt, i + 1) && k !== mod)) {
         if ((k === 0) || (k === mod) || desc.some(e => (e.msb + 1 === i))) {
           res.push(vline(height, xj, 0));
         } else {
           res.push(vline((height >>> 3), xj, 0));
           res.push(vline(-(height >>> 3), xj, height));
         }
-    }
+      }
 
-    if (opt.compact && k !== 0 && !skipField(desc, opt, i)) {
-      res.push(hline(width / mod, xj, 0));
-      res.push(hline(width / mod, xj, height));
+      if (opt.compact && k !== 0 && !skipField(desc, opt, i)) {
+        res.push(hline(width / mod, xj, 0));
+        res.push(hline(width / mod, xj, height));
+      }
+      i++;
+      j += delta;
     }
-    i++;
-    j += delta;
+  } else {
+    for (let k = 0; k < mod; k++) {
+      const xj = j * (width / mod);
+      if ((k === 0) || desc.some(e => (e.lsb === i))) {
+        res.push(vline(height, xj, 0));
+      } else {
+        res.push(
+          vline((height >>> 3), xj, 0),
+          vline(-(height >>> 3), xj, height)
+        );
+      }
+      i++;
+      j += delta;
+    }
   }
   return res;
 };

--- a/lib/render.js
+++ b/lib/render.js
@@ -231,26 +231,13 @@ const compactLabels = (desc, opt) => {
   return labels;
 };
 
-const skipDrawingEmptySpace = (desc, opt, laneIndex, laneLength, globalIndex) => {
-  if (!opt.compact)
-    return false;
-
-  const isEmptyBitfield = (bitfield) => bitfield.name === undefined && bitfield.type === undefined;
-  const bitfieldIndex = desc.findIndex((e) => isEmptyBitfield(e) && globalIndex >= e.lsb && globalIndex <= e.msb + 1);
-
-  if (bitfieldIndex === -1) {
+const skipField = (desc, opt, globalIndex) => {
+  if (!opt.compact) {
     return false;
   }
 
-  if (globalIndex > desc[bitfieldIndex].lsb && globalIndex < desc[bitfieldIndex].msb + 1) {
-    return true;
-  }
-
-  if (globalIndex == desc[bitfieldIndex].lsb && (laneIndex === 0 || bitfieldIndex > 0 && isEmptyBitfield(desc[bitfieldIndex - 1]))) {
-    return true;
-  }
-
-  if (globalIndex == desc[bitfieldIndex].msb + 1 && (laneIndex === laneLength || bitfieldIndex < desc.length - 1 && isEmptyBitfield(desc[bitfieldIndex + 1]))) {
+  const emptyField = (e) => e.name === undefined && e.type === undefined;
+  if (desc.findIndex((e) => emptyField(e) && globalIndex > e.lsb && globalIndex <= e.msb + 1) !== -1) {
     return true;
   }
 
@@ -288,19 +275,18 @@ const cage = (desc, opt) => {
   let j = vflip ? 0 : mod;
 
   for (let k = 0; k <= mod; k++) {
-    if (skipDrawingEmptySpace(desc, opt, k, mod, i)) {
-      i++;
-      j += delta;
-      continue;
-    }
     const xj = j * (width / mod);
-    if ((k === 0) || (k === mod) || desc.some(e => (e.msb + 1 === i))) {
-      res.push(vline(height, xj, 0));
-    } else {
-      res.push(vline((height >>> 3), xj, 0));
-      res.push(vline(-(height >>> 3), xj, height));
+
+    if ((!skipField(desc, opt, i) && k !== 0) || (!skipField(desc, opt, i+1) && k !== mod)) {
+        if ((k === 0) || (k === mod) || desc.some(e => (e.msb + 1 === i))) {
+          res.push(vline(height, xj, 0));
+        } else {
+          res.push(vline((height >>> 3), xj, 0));
+          res.push(vline(-(height >>> 3), xj, height));
+        }
     }
-    if (opt.compact && k !== 0 && !skipDrawingEmptySpace(desc, opt, k - 1, mod, i - 1)) {
+
+    if (opt.compact && k !== 0 && !skipField(desc, opt, i)) {
       res.push(hline(width / mod, xj, 0));
       res.push(hline(width / mod, xj, height));
     }


### PR DESCRIPTION
Before:
![test](https://user-images.githubusercontent.com/18444648/220141187-f4eb5593-8f58-4f2b-abd3-d146bf9e5626.svg)

After:
![test](https://user-images.githubusercontent.com/18444648/220140942-c90d9560-4bef-4946-b861-46ff63c70128.svg)
