### PR TITLE
New meta bit option

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -158,7 +158,7 @@ const labelArr = (desc, opt) => {
           field: e.name,
           style: 'fill-opacity:0.1' + typeStyle(e.type)
         }), 
-          e.rect !== undefined ? e.rect : {}
+        e.rect !== undefined ? e.rect : {}
         )]);
       }
     }

--- a/lib/render.js
+++ b/lib/render.js
@@ -150,8 +150,6 @@ const labelArr = (desc, opt) => {
 
     if ((e.name === undefined) || (e.type !== undefined)) {
       if (!(opt.compact && e.type === undefined)) {
-        var meta = e.meta !== undefined ? JSON.parse(e.meta.replace(/'/g, '"')) : {};
-        
         blanks.push(['rect', Object.assign({}, norm({
           x: step * (vflip ? lsbm : (mod - msbm - 1)),
           width: step * (msbm - lsbm + 1),
@@ -159,7 +157,9 @@ const labelArr = (desc, opt) => {
         }, {
           field: e.name,
           style: 'fill-opacity:0.1' + typeStyle(e.type)
-        }), meta)]);
+        }), 
+          e.rect !== undefined ? e.rect : {}
+        )]);
       }
     }
     if (e.attr !== undefined) {

--- a/lib/render.js
+++ b/lib/render.js
@@ -150,14 +150,16 @@ const labelArr = (desc, opt) => {
 
     if ((e.name === undefined) || (e.type !== undefined)) {
       if (!(opt.compact && e.type === undefined)) {
-        blanks.push(['rect', norm({
+        var meta = e.meta !== undefined ? JSON.parse(e.meta.replace(/'/g, '"')) : {};
+        
+        blanks.push(['rect', Object.assign({}, norm({
           x: step * (vflip ? lsbm : (mod - msbm - 1)),
           width: step * (msbm - lsbm + 1),
           height: height
         }, {
           field: e.name,
           style: 'fill-opacity:0.1' + typeStyle(e.type)
-        })]);
+        }), meta)]);
       }
     }
     if (e.attr !== undefined) {


### PR DESCRIPTION
`  {"bits":1, "name":"loss", "type":3, "meta": "{'field': 'loss', 'parent': 'bla'}"}
`

This way a user can add any number of attributes on fields for later use.